### PR TITLE
Add check of window focus before getting async keyboard input

### DIFF
--- a/src/HexagonClient.cpp
+++ b/src/HexagonClient.cpp
@@ -38,6 +38,12 @@ void getInputs(sf::RenderWindow& window, gameInput& input, displayInput& dispInp
     float posV{};
 
     bool xboxConnected = sf::Joystick::isConnected(0);
+    bool hasFocus = window.hasFocus();
+
+    auto isKeyDown = [&hasFocus](sf::Keyboard::Key key) -> auto {
+        // isKeyPressed also works if window is unfocused. Ensure window is focused.
+        return hasFocus && sf::Keyboard::isKeyPressed(key);
+    };
 
     for (auto event = sf::Event{}; window.pollEvent(event);)
     {
@@ -46,23 +52,23 @@ void getInputs(sf::RenderWindow& window, gameInput& input, displayInput& dispInp
             window.close();
         }
 
-        if (sf::Keyboard::isKeyPressed(sf::Keyboard::BackSpace))
+        if (isKeyDown(sf::Keyboard::BackSpace))
         {
             input.action = actionType::undoMove;
         }
-        else if (sf::Keyboard::isKeyPressed(sf::Keyboard::N))
+        else if (isKeyDown(sf::Keyboard::N))
         {
             input.action = actionType::skipTurn;
         }
-        else if (sf::Keyboard::isKeyPressed(sf::Keyboard::P))
+        else if (isKeyDown(sf::Keyboard::P))
         {
             std::cout << "Pressed P " << std::endl;
         }
-        else if (sf::Keyboard::isKeyPressed(sf::Keyboard::LShift) && sf::Keyboard::isKeyPressed(sf::Keyboard::Z))
+        else if (isKeyDown(sf::Keyboard::LShift) && isKeyDown(sf::Keyboard::Z))
         {
             posZ = -160.f;
         }
-        else if (!sf::Keyboard::isKeyPressed(sf::Keyboard::LShift) && sf::Keyboard::isKeyPressed(sf::Keyboard::Z))
+        else if (!isKeyDown(sf::Keyboard::LShift) && isKeyDown(sf::Keyboard::Z))
         {
             posZ = 160.f;
         }
@@ -92,7 +98,7 @@ void getInputs(sf::RenderWindow& window, gameInput& input, displayInput& dispInp
                 enableShaders = true;
             }
         }
-        else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L))
+        else if (isKeyDown(sf::Keyboard::L))
         {
             configParser.loadConfig(joyThreshHigh, joyThreshLow, seed);
             std::cout << joyThreshHigh << " " << joyThreshLow << std::endl;
@@ -139,36 +145,36 @@ void getInputs(sf::RenderWindow& window, gameInput& input, displayInput& dispInp
         }
     }
 
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::W))
+    if (isKeyDown(sf::Keyboard::W))
     {
         posY = -100.f;
     }
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::A))
+    if (isKeyDown(sf::Keyboard::A))
     {
         posX = -100.f;
     }
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::S))
+    if (isKeyDown(sf::Keyboard::S))
     {
         posY = 100.f;
     }
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::D))
+    if (isKeyDown(sf::Keyboard::D))
     {
         posX = 100.f;
     }
 
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Up))
+    if (isKeyDown(sf::Keyboard::Up))
     {
         posV = -100.f;
     }
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Left))
+    if (isKeyDown(sf::Keyboard::Left))
     {
         posU = -100.f;
     }
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Down))
+    if (isKeyDown(sf::Keyboard::Down))
     {
         posV = 100.f;
     }
-    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Right))
+    if (isKeyDown(sf::Keyboard::Right))
     {
         posU = 100.f;
     }

--- a/src/WizardClient.cpp
+++ b/src/WizardClient.cpp
@@ -194,9 +194,18 @@ int main(int argc, char** argv) {
         connected = GameService.Connect();
 
 
+    bool hasFocus = false;
+
+    auto isKeyDown = [&hasFocus](sf::Keyboard::Key key) -> auto {
+        // isKeyPressed also works if window is unfocused. Ensure window is focused.
+        return hasFocus && sf::Keyboard::isKeyPressed (key);
+    };
+
     while (window.isOpen())
     {
         actionType action{ actionType::none };
+
+        hasFocus = window.hasFocus();
 
         for (auto event = sf::Event{}; window.pollEvent(event);)
         {
@@ -205,27 +214,27 @@ int main(int argc, char** argv) {
                 window.close();
             }
 
-            if (sf::Keyboard::isKeyPressed(sf::Keyboard::Up))
+            if (isKeyDown(sf::Keyboard::Up))
             {
                 action = actionType::up;
             }
-            else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Down))
+            else if (isKeyDown(sf::Keyboard::Down))
             {
                 action = actionType::down;
             }
-            else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Left))
+            else if (isKeyDown(sf::Keyboard::Left))
             {
                 action = actionType::left;
             }
-            else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Right))
+            else if (isKeyDown(sf::Keyboard::Right))
             {
                 action = actionType::right;
             }
-            else if (sf::Keyboard::isKeyPressed(sf::Keyboard::BackSpace))
+            else if (isKeyDown(sf::Keyboard::BackSpace))
             {
                 action = actionType::undoMove;
             }
-            else if (sf::Keyboard::isKeyPressed(sf::Keyboard::N))
+            else if (isKeyDown(sf::Keyboard::N))
             {
                 action = actionType::skipTurn;
             }


### PR DESCRIPTION
Fixes bug where the keybd input is also captured when the client window is not focused.

The bug results in both clients processing controls (W/S/A/D) which is invalid (an btw results in a very cool effect!)